### PR TITLE
Implement solutions running in parallel

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -13,6 +13,7 @@ def main(argv = None):
     parser.add_argument('-c', '--checker', help = "compile checker & interactor", action = "store_true")
     parser.add_argument('-s', '--solutions', help = "compile all solutions", action = "store_true")
     parser.add_argument('-g', '--generators', help = "compile all generators", action = "store_true")
+    parser.add_argument('-j', '--parallel', help = "spawn processes in parallel", action = "store_true")
     parser.add_argument('-a', '--all', help = "compile all problem stuff (shortcut for -v -c -s -g)", action = "store_true")
     args = parser.parse_args(argv)
     if args.all:
@@ -31,7 +32,7 @@ def main(argv = None):
         compile_list.extend(args.sources)
         compile_list.extend(get_sources_in_problem(validator = args.validator, checker = args.checker, solutions = args.solutions, generators = args.generators))
 
-    compile_results = compile_sources(compile_list, cfg)
+    compile_results = compile_sources(compile_list, cfg, args.parallel)
     print_compile_results(compile_results)
 
     ret_code = 0

--- a/fixeoln.py
+++ b/fixeoln.py
@@ -24,7 +24,7 @@ def main(argv = None):
         with open(fname, 'wb') as f:
             f.write(convert_eoln(data, style))
 
-    return 0;
+    return 0
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/nsuolymp_cfg.py
+++ b/nsuolymp_cfg.py
@@ -21,7 +21,7 @@ default_compiler_order = {
     "pas": ["dcc32", "fpc"],
     "java": ["javac"],
     "kotlin": ["kotlinc"],
-    "python": ["python"],
+    "python": ["python3"],
 }
 
 # NSUTs credentials and contest options

--- a/testsol.py
+++ b/testsol.py
@@ -18,6 +18,7 @@ def main(argv = None):
     parser.add_argument('-t', '--tl', help = "specify time limit in seconds (by default taken from problem statement, 0 means 'no limit')", type = float)
     parser.add_argument('-m', '--ml', help = "specify memory limit in megabytes (by default taken from problem statement, 0 means 'no limit')", type = float)
     parser.add_argument('-i', '--tests', help = "comma-separated list of test names/globs/ranges to run on (by default all tests are used)", metavar = "TESTS")
+    parser.add_argument('-j', '--parallel', help = "spawn processes in parallel", action = "store_true")
     parser.add_argument('--nsuts', help = "test solutions on the remote nsuts testing server", action = "store_true")
     parser.add_argument('--local', help = "test solutions locally (default)", action = "store_true")
     args = parser.parse_args(argv)
@@ -75,7 +76,7 @@ def main(argv = None):
                 sol_prelist.append(exe)
 
         # compile all the necessary sources
-        compile_results = compile_sources(compile_list, cfg)
+        compile_results = compile_sources(compile_list, cfg, args.parallel)
         if len(compile_results[1]) > 0:
             on_error(10)
 
@@ -99,11 +100,11 @@ def main(argv = None):
                 on_error(12, True)
         elif args.gen_output:
             solution = solutions_list[0]
-            test_results = [(solution, check_solution(cfg, solution, args.tests, True))]
+            test_results = [(solution, check_solution(cfg, solution, args.tests, args.parallel))]
         else:
             test_results = []
             if args.local:
-                test_results = test_results + check_many_solutions(cfg, solutions_list, args.tests)
+                test_results = test_results + check_many_solutions(cfg, solutions_list, args.tests, args.parallel)
             if args.nsuts:
                 if path.isfile('nsuts.json'):
                     with open('nsuts.json') as f:

--- a/validate.py
+++ b/validate.py
@@ -13,6 +13,7 @@ def main(argv = None):
     parser.add_argument('-s', '--samples', help = "check that samples are taken from statements", action = "store_true")
     parser.add_argument('-i', '--indices', help = "check tests' names", action = "store_true")
     parser.add_argument('-o', '--output', help = "check that outputs for tests are present", action = "store_true")
+    parser.add_argument('-j', '--parallel', help = "spawn processes in parallel", action = "store_true")
     parser.add_argument('-a', '--all', help = "check everything (implies -v, -s, -i, -o)", action = "store_true")
     args = parser.parse_args(argv)
     if args.all:
@@ -41,7 +42,7 @@ def main(argv = None):
     try:
         # compile validator (if asked for)
         if args.compile:
-            compile_results = compile_sources(get_sources_in_problem(validator = args.validator, checker = args.samples), cfg)
+            compile_results = compile_sources(get_sources_in_problem(validator = args.validator, checker = args.samples), cfg, args.parallel)
             if len(compile_results[1]) > 0:
                 on_error(1)
         # run all types of validation


### PR DESCRIPTION
Я тут решил оправдать покупку многоядерного процессора. Суть изменений в том, что запуск процессов решений на тестах теперь делается одновременно пачкой. Обёрнуто в стандартный питоновский тредпул, чтоб всё-таки пачкой мы 100 процессов разом не запустили. Заодно и для команды компиляции опцию добавил, чтоб не ждать пока мы последовательно все исходники соберём.

С точки зрения использования для скриптов compile.py и testsol.py теперь добавился флаг -j. На выхлоп в консоли после этого, конечно же, лучше не смотреть: каша кашей.

Удобно использовать в тех случаях, когда немного пофиг на TL, а хочется прогнать все решения на каком-то множестве тестов и собрать вердикты - отрабатывает прям нереально быстрее относительно последовательного варианта. Ну и с компиляцией мелочь, а приятно.